### PR TITLE
Potential fix for code scanning alert no. 12: Creating an ASP.NET debug binary may reveal sensitive information

### DIFF
--- a/WebApplication1/bin/WebApplication1.dll.config
+++ b/WebApplication1/bin/WebApplication1.dll.config
@@ -11,7 +11,7 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <system.web>
-    <compilation debug="true" targetFramework="4.8.1" />
+    <compilation debug="false" targetFramework="4.8.1" />
     <httpRuntime targetFramework="4.8.1" />
   </system.web>
   <system.webServer>


### PR DESCRIPTION
Potential fix for [https://github.com/greg-martinage/GHAS_Testing/security/code-scanning/12](https://github.com/greg-martinage/GHAS_Testing/security/code-scanning/12)

To fix the issue, the `debug` attribute in the `<compilation>` element should be set to `false`. This ensures that the application does not include debugging information in the output, reducing the risk of exposing sensitive information and improving performance. The change should be made directly in the `WebApplication1/bin/WebApplication1.dll.config` file on line 14.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
